### PR TITLE
Make buildable and update Antlr

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <name>pcre-parser</name>
 
   <properties>
-    <antlr4.version>4.9.2</antlr4.version>
+    <antlr4.version>4.11.1</antlr4.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -23,13 +23,6 @@
     <dependency>
       <groupId>org.antlr</groupId>
       <artifactId>antlr4-runtime</artifactId>
-      <version>${antlr4.version}</version>
-      <scope>compile</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.antlr</groupId>
-      <artifactId>antlr4-maven-plugin</artifactId>
       <version>${antlr4.version}</version>
       <scope>compile</scope>
     </dependency>

--- a/src/main/antlr4/nl/bigo/pcreparser/PCRE.g4
+++ b/src/main/antlr4/nl/bigo/pcreparser/PCRE.g4
@@ -112,13 +112,16 @@ quantifier_type
 //       default,  but  some  of them use Unicode properties if PCRE_UCP is set.
 //       You can use \Q...\E inside a character class.
 character_class
- : '[' '^' CharacterClassEnd Hyphen cc_atom+ ']'
- | '[' '^' CharacterClassEnd cc_atom* ']'
- | '[' '^' cc_atom+ ']'
- | '[' CharacterClassEnd Hyphen cc_atom+ ']'
- | '[' CharacterClassEnd cc_atom* ']'
- | '[' cc_atom+ ']'
+ : '[' '^' CharacterClassEnd Hyphen cc_atom+ sub_character_class* ']'
+ | '[' '^' CharacterClassEnd cc_atom* sub_character_class* ']'
+ | '[' '^' cc_atom+ sub_character_class* ']'
+ | '[' CharacterClassEnd Hyphen cc_atom+ sub_character_class* ']'
+ | '[' CharacterClassEnd cc_atom* sub_character_class* ']'
+ | '[' cc_atom+ sub_character_class* ']'
  ;
+
+sub_character_class 
+ : DoubleAmpersand character_class;
 
 // BACKREFERENCES
 //
@@ -677,6 +680,7 @@ Hash        : '#';
 Equals      : '=';
 Exclamation : '!';
 Ampersand   : '&';
+DoubleAmpersand   : '&&';
 
 ALC : 'a';
 BLC : 'b';


### PR DESCRIPTION
* Use Antlr 4.11.1.
* Remove odd *dependency* on the Maven plugin, which makes this project un-buildable (since it creates a `jar` dependency to a `maven-plugin` artifact) - it is unnecssary.